### PR TITLE
Check for existing Maintenance Mode before starting Maintenance

### DIFF
--- a/Demo.SCOM.AgentMaintenanceMode.xml
+++ b/Demo.SCOM.AgentMaintenanceMode.xml
@@ -172,19 +172,31 @@ ELSE
 
   # Clear any previous errors
   $Error.Clear()
-  # Call maintenance mode:
-  Start-SCOMMaintenanceMode -Instance $AgentWindowsComputer -EndTime $EndTime -Comment $Comment -Reason $Reason
-  # Check for any errors
-  IF ($Error) 
-  { 
-    $momapi.LogScriptEvent($ScriptName,$EventID,2,"`n Error setting Maintenance Mode for computer: ($WCDisplayName) with AgentName: ($AgentName). `n Error is: ($Error).")
-  }
-  ELSE
-  {
-    # Log event for no errors
-    $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Maintenance mode was set for computer: ($WCDisplayName).")
+    $Error.Clear()
+  # #Edit MarcPosch: Check for existing Maintenance Windows
+  $MM=Get-SCOMMaintenanceMode -Instance $AgentWindowsComputer
 
-    #Consider adding a check here to see if it is really in MM.  This might add additional SDK time to the script however.
+  if ($MM.Count -ge 1) {
+    $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n EXISTING Maintenance Windows for Windows Computer Object found. `n SKIPPING Maintenance Window Creation.")
+
+    # Clear any previous errors
+    $Error.Clear()
+  }
+  else {
+    # Call maintenance mode:
+    Start-SCOMMaintenanceMode -Instance $AgentWindowsComputer -EndTime $EndTime -Comment $Comment -Reason $Reason
+    # Check for any errors
+    IF ($Error) 
+    { 
+      $momapi.LogScriptEvent($ScriptName,$EventID,2,"`n Error setting Maintenance Mode for computer: ($WCDisplayName) with AgentName: ($AgentName). `n Error is: ($Error).")
+    }
+    ELSE
+    {
+      # Log event for no errors
+      $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Maintenance mode was set for computer: ($WCDisplayName).")
+
+      #Consider adding a check here to see if it is really in MM.  This might add additional SDK time to the script however.
+    }
   }
 }
 #=================================================================================


### PR DESCRIPTION
Hello Kevin,

I am using your solution in our environment since December 2020 and have found issues when a scheduled or manual maintenance mode already exists on the windows computer.
The issue is, that after a planned server reboot, where most of the colleagues set a maintenance mode on SCOM manually, the SCCM client starts several times a maintenance window, this triggering SCOM maintenance mode, and overwriting any maintenance mode previously set on the windows computer.
This causes angry comments like "I've surely set maintenance mode on this computer, why is it gone away now?"

I have not found out why these on-demand maintenance windows are set by SCCM, but if I try to filter them away by setting the allowed types of service windows to 3 and 4 in SCOM.AgentMaintenanceMode.SCCMServiceWindows.Rule.ps1, I still get these unplanned service windows anyway.
I will still have to investigate further into this issue, because it does not solve the case of manual cluster patching: 
After having rebooted the first node and manually stopped maintenance mode there, and starting maintenance on the second node, suddenly after some minutes the first node is in maintenance again because of a delayed automatic SCCM Maintenance window. This is causing alerts of all hosted cluster groups because now both nodes are in maintenance - and this is not what the user expected.

This is an attempt to quick fix the first issue above by skipping MM Start if MM already exists.

Regards,
Marc